### PR TITLE
adb remount しないと mount: Permission denied になる

### DIFF
--- a/patch-apn.sh
+++ b/patch-apn.sh
@@ -24,6 +24,7 @@ patch shared/resources/apn.json $PATCHDIR/apn.json.diff
 zip -u application.zip shared/resources/apn.json
 
 # Remount file systems and push to the device
+$ADB remount
 $ADB shell mount -o remount rw /system
 $ADB push application.zip $SETTINGS_APP_INSTALL_PATH/application.zip
 


### PR DESCRIPTION
Flame(fxos2.0 nightly-b2g32)でのんきにやると、
mount: Permission denied
failed to copy 'application.zip' to '/system/b2g/webapps/settings.gaiamobile.org/application.zip': Read-only file system
と出たので、./adb remount したあとに ./patch-apn.sh すれば正常に完了したけど、ここでremountするのが正しいかまでは検証してません...
