### PR TITLE
fix mount option.

### DIFF
--- a/patch-apn.sh
+++ b/patch-apn.sh
@@ -24,7 +24,7 @@ patch shared/resources/apn.json $PATCHDIR/apn.json.diff
 zip -u application.zip shared/resources/apn.json
 
 # Remount file systems and push to the device
-$ADB shell mount -o remount rw /system
+$ADB shell mount -o remount -rw /system
 $ADB push application.zip $SETTINGS_APP_INSTALL_PATH/application.zip
 
 # Reboot


### PR DESCRIPTION
Mac OS X Yosemiteを使っています。
Flameでpatchを当てようとしたところ、mountできなかったためエラーになっていました。
`-rw`にしたところ、成功しました。
